### PR TITLE
Fix a broken link in the singularity part

### DIFF
--- a/block1/intro-singularity.md
+++ b/block1/intro-singularity.md
@@ -23,7 +23,7 @@ The workflow we recommend for most researchers is to create Docker containers of
 
 ## Machine Learning App with Singularity Runtime
 In this tutorial, we will run a Machine Learning Image Classifier app that uses Singularity Runtime. You are not required to install Singularity today. Rest of this page can be completed as a self exercise.
-You may now navigate to [Intro to Tapis Systems](../block3/tapis-systems/)
+You may now navigate to [Intro to Tapis Systems](../block3/tapis-systems.md)
 
 
 ## Further Reading: (Not Needed For the Tutorial Today - Use At Home)

--- a/block1/intro-singularity.md
+++ b/block1/intro-singularity.md
@@ -23,7 +23,7 @@ The workflow we recommend for most researchers is to create Docker containers of
 
 ## Machine Learning App with Singularity Runtime
 In this tutorial, we will run a Machine Learning Image Classifier app that uses Singularity Runtime. You are not required to install Singularity today. Rest of this page can be completed as a self exercise.
-You may now navigate to [Intro to Tapis Systems](https://tacc-cloud.github.io/gateways21-portable-computing-cloud-hpc/block3/tapis-systems/)
+You may now navigate to [Intro to Tapis Systems](../block3/tapis-systems/)
 
 
 ## Further Reading: (Not Needed For the Tutorial Today - Use At Home)


### PR DESCRIPTION
The previous docs had a hard link to an old gateways tutorial. I'm replacing the link with a relative link to the correct doc within the repo